### PR TITLE
Migrate to GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,50 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    continue-on-error: ${{ matrix.ruby-version == 'head' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head']
+
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - name: Install libcurl dev (for ovirt native extensions)
+      run: sudo apt-get install libcurl4-openssl-dev
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Install dependencies
+      run: bundle install
+    - name: Run tests
+      run: bundle exec rake
+
+  rubocop:
+    name: Rubocop
+    runs-on: 'ubuntu-20.04'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '2.7'
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run Rubocop
+      run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ inherit_from: .rubocop_todo.yml
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
   Enabled: false
 
@@ -31,3 +31,4 @@ Gemspec/RequiredRubyVersion:
 AllCops:
   Exclude:
   - 'lib/fog/ovirt/compute.rb'
+  - 'vendor/**/*'

--- a/fog-ovirt.gemspec
+++ b/fog-ovirt.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.test_files    = spec.files.grep(%r{^tests\/})
+  spec.test_files    = spec.files.grep(%r{^tests/})
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.0.0"
 
@@ -27,8 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("ovirt-engine-sdk", ">= 4.3.1")
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rubocop", "~> 0.52"
+  spec.add_development_dependency "rubocop", "~> 1.0"
   spec.add_development_dependency "shindo"
 end

--- a/lib/fog/ovirt/models/compute/interface.rb
+++ b/lib/fog/ovirt/models/compute/interface.rb
@@ -3,6 +3,7 @@ module Fog
     class Compute
       class Interface < Fog::Model
         attr_accessor :raw
+
         identity :id
 
         attribute :name

--- a/lib/fog/ovirt/models/compute/interfaces.rb
+++ b/lib/fog/ovirt/models/compute/interfaces.rb
@@ -11,9 +11,10 @@ module Fog
 
         def all(_filters = {})
           requires :vm
-          if vm.is_a? Fog::Ovirt::Compute::Server
+          case vm
+          when Fog::Ovirt::Compute::Server
             load service.list_vm_interfaces(vm.id)
-          elsif vm.is_a? Fog::Ovirt::Compute::Template
+          when Fog::Ovirt::Compute::Template
             load service.list_template_interfaces(vm.id)
           else
             raise ::Fog::Ovirt::Errors::OvirtError, "interfaces should have vm or template"

--- a/lib/fog/ovirt/models/compute/operating_system.rb
+++ b/lib/fog/ovirt/models/compute/operating_system.rb
@@ -3,6 +3,7 @@ module Fog
     class Compute
       class OperatingSystem < Fog::Model
         attr_accessor :raw
+
         identity :id
 
         attribute :name

--- a/lib/fog/ovirt/models/compute/volume.rb
+++ b/lib/fog/ovirt/models/compute/volume.rb
@@ -3,6 +3,7 @@ module Fog
     class Compute
       class Volume < Fog::Model
         attr_accessor :raw
+
         identity :id
 
         attribute :storage_domain

--- a/lib/fog/ovirt/models/compute/volumes.rb
+++ b/lib/fog/ovirt/models/compute/volumes.rb
@@ -10,9 +10,10 @@ module Fog
         attr_accessor :vm
 
         def all(_filters = {})
-          if vm.is_a? Fog::Ovirt::Compute::Server
+          case vm
+          when Fog::Ovirt::Compute::Server
             load service.list_vm_volumes(vm.id)
-          elsif vm.is_a? Fog::Ovirt::Compute::Template
+          when Fog::Ovirt::Compute::Template
             load service.list_template_volumes(vm.id)
           else
             load service.list_volumes

--- a/lib/fog/ovirt/requests/compute/v4/get_api_version.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_api_version.rb
@@ -7,6 +7,7 @@ module Fog
             "4.0"
           end
         end
+
         class Mock
           def api_version
             "4.0"

--- a/lib/fog/ovirt/requests/compute/v4/get_cluster.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_cluster.rb
@@ -7,6 +7,7 @@ module Fog
             ovirt_attrs client.system_service.clusters_service.cluster_service(id).get
           end
         end
+
         class Mock
           def get_cluster(_id)
             xml = read_xml("cluster.xml")

--- a/lib/fog/ovirt/requests/compute/v4/get_instance_type.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_instance_type.rb
@@ -7,6 +7,7 @@ module Fog
             ovirt_attrs client.system_service.instance_types_service.instance_type_service(id).get
           end
         end
+
         class Mock
           def get_instance_type(_id)
             xml = read_xml "instance_type.xml"

--- a/lib/fog/ovirt/requests/compute/v4/get_quota.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_quota.rb
@@ -8,6 +8,7 @@ module Fog
             ovirt_attrs quota
           end
         end
+
         class Mock
           def get_quota(_id)
             xml = read_xml("quota.xml")

--- a/lib/fog/ovirt/requests/compute/v4/get_template.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_template.rb
@@ -7,6 +7,7 @@ module Fog
             ovirt_attrs client.system_service.templates_service.template_service(id).get
           end
         end
+
         class Mock
           def get_template(_id)
             xml = read_xml "template.xml"

--- a/lib/fog/ovirt/requests/compute/v4/get_virtual_machine.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_virtual_machine.rb
@@ -7,6 +7,7 @@ module Fog
             ovirt_attrs client.system_service.vms_service.vm_service(id).get(:all_content => true)
           end
         end
+
         class Mock
           def get_virtual_machine(_id)
             xml = read_xml "vm.xml"

--- a/lib/fog/ovirt/requests/compute/v4/get_volume.rb
+++ b/lib/fog/ovirt/requests/compute/v4/get_volume.rb
@@ -7,6 +7,7 @@ module Fog
             ovirt_attrs client.system_service.disks_service.disk_service(id).get
           end
         end
+
         class Mock
           def get_volume(_id)
             xml = read_xml("disk.xml")

--- a/lib/fog/ovirt/requests/compute/v4/list_clusters.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_clusters.rb
@@ -8,6 +8,7 @@ module Fog
             client.system_service.clusters_service.list(opts).map { |ovirt_obj| ovirt_attrs(ovirt_obj) }
           end
         end
+
         class Mock
           def list_clusters(_filters = {})
             xml = read_xml "clusters.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_instance_types.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_instance_types.rb
@@ -7,6 +7,7 @@ module Fog
             client.system_service.instance_types_service.list(filters).map { |ovirt_obj| ovirt_attrs ovirt_obj }
           end
         end
+
         class Mock
           def list_instance_types(_filters = {})
             xml = read_xml "instance_types.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_networks.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_networks.rb
@@ -7,6 +7,7 @@ module Fog
             client.system_service.clusters_service.cluster_service(cluster_id).networks_service.list
           end
         end
+
         class Mock
           def list_networks(_cluster_id)
             []

--- a/lib/fog/ovirt/requests/compute/v4/list_operating_systems.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_operating_systems.rb
@@ -7,6 +7,7 @@ module Fog
             client.system_service.operating_systems_service.list.map { |ovirt_obj| ovirt_attrs ovirt_obj }
           end
         end
+
         class Mock
           def list_operating_systems
             xml = read_xml "operating_systems.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_quotas.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_quotas.rb
@@ -8,6 +8,7 @@ module Fog
             data_center.quotas_service.list(filters).map { |ovirt_obj| ovirt_attrs ovirt_obj }
           end
         end
+
         class Mock
           def list_quotas(_filters = {})
             xml = read_xml "quotas.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_template_interfaces.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_template_interfaces.rb
@@ -7,6 +7,7 @@ module Fog
             client.system_service.templates_service.template_service(vm_id).nics_service.list.map { |ovirt_obj| ovirt_attrs ovirt_obj }
           end
         end
+
         class Mock
           def list_template_interfaces(_vm_id)
             xml = read_xml "nics.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_template_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_template_volumes.rb
@@ -18,6 +18,7 @@ module Fog
             end
           end
         end
+
         class Mock
           def list_template_volumes(_template_id)
             xml = read_xml "volumes.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_templates.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_templates.rb
@@ -7,6 +7,7 @@ module Fog
             client.system_service.templates_service.list(filters).map { |ovirt_obj| ovirt_attrs ovirt_obj }
           end
         end
+
         class Mock
           def list_templates(_filters = {})
             xml = read_xml "templates.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_virtual_machines.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_virtual_machines.rb
@@ -12,6 +12,7 @@ module Fog
             client.system_service.vms_service.list(filters).map { |ovirt_obj| ovirt_attrs ovirt_obj }
           end
         end
+
         class Mock
           def list_virtual_machines(_filters = {})
             xml = read_xml "vms.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_vm_interfaces.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_vm_interfaces.rb
@@ -7,6 +7,7 @@ module Fog
             client.system_service.vms_service.vm_service(vm_id).nics_service.list.map { |ovirt_obj| ovirt_attrs ovirt_obj }
           end
         end
+
         class Mock
           def list_vm_interfaces(_vm_id)
             xml = read_xml "nics.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_vm_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_vm_volumes.rb
@@ -18,6 +18,7 @@ module Fog
             end
           end
         end
+
         class Mock
           def list_vm_volumes(_vm_id)
             xml = read_xml "volumes.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_vnic_profiles.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_vnic_profiles.rb
@@ -13,6 +13,7 @@ module Fog
             dc_vnics
           end
         end
+
         class Mock
           def list_vnic_profiles(_filters = {})
             xml = read_xml "vnic_profiles.xml"

--- a/lib/fog/ovirt/requests/compute/v4/list_volumes.rb
+++ b/lib/fog/ovirt/requests/compute/v4/list_volumes.rb
@@ -7,6 +7,7 @@ module Fog
             client.system_service.disks_service.list.map { |ovirt_obj| ovirt_attrs ovirt_obj }
           end
         end
+
         class Mock
           def list_volumes
             xml = read_xml "disks.xml"

--- a/tests/helpers/succeeds_helper.rb
+++ b/tests/helpers/succeeds_helper.rb
@@ -1,8 +1,9 @@
 module Shindo
   class Tests
-    def succeeds
+    def succeeds(&block)
       test("succeeds") do
-        !!instance_eval(&Proc.new)
+        p = block_given? ? block : proc {}
+        !!instance_eval(&p)
       end
     end
   end

--- a/tests/ovirt/requests/compute/v4/client_tests.rb
+++ b/tests/ovirt/requests/compute/v4/client_tests.rb
@@ -14,18 +14,14 @@ Shindo.tests("Fog::Ovirt::Compute.new | client", ["ovirt"]) do
   end
 
   tests("The exception test is as expected").returns(true) do
-    begin
-      @object_under_test.foo
-    rescue Fog::Ovirt::Errors::OvirtEngineError => e
-      e.message == "Ovirt client returned an error: Test"
-    end
+    @object_under_test.foo
+  rescue Fog::Ovirt::Errors::OvirtEngineError => e
+    e.message == "Ovirt client returned an error: Test"
   end
 
   tests("The original exception test is as expected").returns(true) do
-    begin
-      @object_under_test.foo
-    rescue Fog::Ovirt::Errors::OvirtEngineError => e
-      e.orig_exception.message == "Test"
-    end
+    @object_under_test.foo
+  rescue Fog::Ovirt::Errors::OvirtEngineError => e
+    e.orig_exception.message == "Test"
   end
 end

--- a/tests/ovirt/requests/compute/v4/create_vm_tests.rb
+++ b/tests/ovirt/requests/compute/v4/create_vm_tests.rb
@@ -3,13 +3,13 @@ Shindo.tests("Fog::Ovirt::Compute v4 | vm_create request", "ovirt") do
   name_base = Time.now.to_i
 
   tests("Create VM") do
-    response = compute.create_vm(:name => "fog-" + name_base.to_s, :cluster_name => "Default")
+    response = compute.create_vm(:name => "fog-#{name_base}", :cluster_name => "Default")
     test("should be a kind of OvirtSDK4::Vm") { response.is_a? OvirtSDK4::Vm }
     test("should be a 'OvirtSDK4::VmType::SERVER' VM type by default") { response.type == OvirtSDK4::VmType::SERVER }
   end
 
   tests("Create VM from template (clone)") do
-    response = compute.create_vm(:name => "fog-" + (name_base + 1).to_s, :template_name => "hwp_small", :cluster_name => "Default")
+    response = compute.create_vm(:name => "fog-#{name_base + 1}", :template_name => "hwp_small", :cluster_name => "Default")
     test("should be a kind of OvirtSDK4::Vm") { response.is_a? OvirtSDK4::Vm }
   end
 

--- a/tests/ovirt/requests/compute/v4/destroy_vm_tests.rb
+++ b/tests/ovirt/requests/compute/v4/destroy_vm_tests.rb
@@ -1,6 +1,6 @@
 Shindo.tests("Fog::Ovirt::Compute v4 | vm_destroy request", ["ovirt"]) do
   compute = Fog::Ovirt::Compute.new(:api_version => "v4")
-  compute.create_vm(:name => "fog-" + Time.now.to_i.to_s, :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
+  compute.create_vm(:name => "fog-#{Time.now.to_i}", :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
   vm_id = compute.servers.all(:search => "fog-*").last.id
 
   tests("The response should") do

--- a/tests/ovirt/requests/compute/v4/update_volume_tests.rb
+++ b/tests/ovirt/requests/compute/v4/update_volume_tests.rb
@@ -1,6 +1,6 @@
 Shindo.tests("Fog::Ovirt::Compute.new v4 | update_volume request", ["ovirt"]) do
   compute = Fog::Compute.new(:provider => :ovirt, :api_version => "v4")
-  compute.create_vm(:name => "fog-" + Time.now.to_i.to_s, :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
+  compute.create_vm(:name => "fog-#{Time.now.to_i}", :cluster_name => "Default") if compute.servers.all(:search => "fog-*").empty?
   vm_id = compute.servers.all(:search => "fog-*").last
 
   tests("The expected options") do


### PR DESCRIPTION
Migrate CI to GitHub actions, including Rubocop.

Upgrade Rubocop to ~> 1.0 and address lints.